### PR TITLE
Avoid casting to Swift types

### DIFF
--- a/Benchmarks/NSFoundationDarwin/Sources/main.swift
+++ b/Benchmarks/NSFoundationDarwin/Sources/main.swift
@@ -9,7 +9,7 @@ extension User.Friend {
 
   public init(json: Any) throws {
     guard
-      let json  = json as? [String: Any],
+      let json  = json as? NSDictionary,
       let id    = json["id"] as? Int,
       let name  = json["name"] as? String
       else { throw JSONError.typeMismatch }
@@ -23,7 +23,7 @@ extension User {
 
   public init(json: Any) throws {
     guard
-      let json              = json as? [String: Any],
+      let json              = json as? NSDictionary,
       let id                = json["_id"] as? String,
       let index             = json["index"] as? Int,
       let guid              = json["guid"] as? String,
@@ -45,7 +45,7 @@ extension User {
       let latitude          = json["latitude"] as? Double,
       let longitude         = json["longitude"] as? Double,
       let tags              = json["tags"] as? [String],
-      let friendsObjects    = json["friends"] as? [Any],
+      let friendsObjects    = json["friends"] as? NSArray,
       //let tags          = json["tags"].array?.flatMap({ $0.string }) ?? []
       //let friends       = try json["friends"].array?.map(Friend.init) ?? []
       let greeting          = json["greeting"] as? String,
@@ -98,7 +98,7 @@ let modelResults = try bench { bytes in
   let data = Data(bytes: bytes)
 
   let json: Any = try JSONSerialization.jsonObject(with: data)
-  guard let array = json as? [Any] else { fatalError() }
+  guard let array = json as? NSArray else { fatalError() }
   _ = try array.map(User.init)
 }
 


### PR DESCRIPTION
Casting from `Foundation` types to native swift ones can be quite expensive. Think avoiding it would be fairer.

This improves foundation Model performance from 110 ms to 20 ms on my machine - just slightly slower than `vdka`.

<img width="1562" alt="skarmavbild 2016-09-21 kl 01 34 04" src="https://cloud.githubusercontent.com/assets/304423/18692876/a991ebd8-7f9d-11e6-9e7d-00d0955879fe.png">
(after, before)
